### PR TITLE
[DM-35001] Add service_ref for cutout service, switch to Jinja2

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,22 +17,18 @@ asgiref==3.5.2
     #   uvicorn
 attrs==21.4.0
     # via pytest
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -c requirements/main.txt
     #   httpcore
     #   httpx
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==2.0.12
-    # via
-    #   -c requirements/main.txt
-    #   httpx
 click==8.1.3
     # via
     #   -c requirements/main.txt
     #   uvicorn
-coverage[toml]==6.3.3
+coverage[toml]==6.4
     # via
     #   -r requirements/dev.in
     #   pytest-cov
@@ -45,7 +41,7 @@ h11==0.12.0
     #   -c requirements/main.txt
     #   httpcore
     #   uvicorn
-httpcore==0.14.7
+httpcore==0.15.0
     # via
     #   -c requirements/main.txt
     #   httpx
@@ -53,11 +49,11 @@ httptools==0.4.0
     # via
     #   -c requirements/main.txt
     #   uvicorn
-httpx==0.22.0
+httpx==0.23.0
     # via
     #   -c requirements/main.txt
     #   -r requirements/dev.in
-identify==2.5.0
+identify==2.5.1
     # via pre-commit
 idna==3.3
     # via
@@ -66,7 +62,7 @@ idna==3.3
     #   rfc3986
 iniconfig==1.1.1
     # via pytest
-mypy==0.950
+mypy==0.960
     # via -r requirements/dev.in
 mypy-extensions==0.4.3
     # via mypy

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -7,14 +7,15 @@
 
 # These dependencies are for fastapi including some optional features.
 fastapi
-gunicorn
 starlette
 uvicorn[standard]
 
 # Other dependencies.
-safir
-astropy
-boto3
-git+https://github.com/lsst/daf_butler.git@main#daf_butler
-psycopg2
 google-cloud-storage
+jinja2
+safir
+
+# lsst.daf.butler is not yet on PyPI
+git+https://github.com/lsst/daf_butler.git@main#daf_butler
+boto3
+psycopg2

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -11,28 +11,25 @@ anyio==3.6.1
     #   watchgod
 asgiref==3.5.2
     # via uvicorn
-astropy==5.0.4
+astropy==5.1
     # via
-    #   -r requirements/main.in
     #   daf-butler
     #   healpy
-boto3==1.23.1
+boto3==1.23.9
     # via -r requirements/main.in
-botocore==1.26.1
+botocore==1.26.10
     # via
     #   boto3
     #   s3transfer
 cachetools==5.1.0
     # via google-auth
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   httpcore
     #   httpx
     #   requests
 charset-normalizer==2.0.12
-    # via
-    #   httpx
-    #   requests
+    # via requests
 click==8.1.3
     # via
     #   daf-butler
@@ -49,7 +46,7 @@ fastapi==0.78.0
     #   safir
 fonttools==4.33.3
     # via matplotlib
-google-api-core==2.7.3
+google-api-core==2.8.1
     # via
     #   google-cloud-core
     #   google-cloud-storage
@@ -64,31 +61,31 @@ google-cloud-storage==2.3.0
     # via -r requirements/main.in
 google-crc32c==1.3.0
     # via google-resumable-media
-google-resumable-media==2.3.2
+google-resumable-media==2.3.3
     # via google-cloud-storage
-googleapis-common-protos==1.56.1
+googleapis-common-protos==1.56.2
     # via google-api-core
 greenlet==1.1.2
     # via sqlalchemy
-gunicorn==20.1.0
-    # via -r requirements/main.in
 h11==0.12.0
     # via
     #   httpcore
     #   uvicorn
 healpy==1.15.2
     # via lsst-sphgeom
-httpcore==0.14.7
+httpcore==0.15.0
     # via httpx
 httptools==0.4.0
     # via uvicorn
-httpx==0.22.0
+httpx==0.23.0
     # via safir
 idna==3.3
     # via
     #   anyio
     #   requests
     #   rfc3986
+jinja2==3.1.2
+    # via -r requirements/main.in
 jmespath==1.0.0
     # via
     #   boto3
@@ -103,9 +100,11 @@ lsst-utils @ git+https://github.com/lsst/utils@main
     # via
     #   daf-butler
     #   lsst-resources
+markupsafe==2.1.1
+    # via jinja2
 matplotlib==3.5.2
     # via healpy
-numpy==1.22.3
+numpy==1.22.4
     # via
     #   astropy
     #   healpy
@@ -117,7 +116,7 @@ packaging==21.3
     # via
     #   astropy
     #   matplotlib
-pillow==9.1.0
+pillow==9.1.1
     # via matplotlib
 protobuf==3.20.1
     # via
@@ -132,7 +131,7 @@ pyasn1==0.4.8
     #   rsa
 pyasn1-modules==0.2.8
     # via google-auth
-pydantic==1.9.0
+pydantic==1.9.1
     # via
     #   daf-butler
     #   fastapi
@@ -166,7 +165,7 @@ s3transfer==0.5.2
     # via boto3
 safir==3.0.3
     # via -r requirements/main.in
-scipy==1.8.0
+scipy==1.8.1
     # via healpy
 six==1.16.0
     # via
@@ -202,7 +201,3 @@ websockets==10.3
     # via uvicorn
 wrapt==1.14.1
     # via deprecated
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==62.3.0
-    # via gunicorn

--- a/src/datalinker/config.py
+++ b/src/datalinker/config.py
@@ -12,6 +12,12 @@ __all__ = ["Configuration", "config"]
 class Configuration:
     """Configuration for datalinker."""
 
+    cutout_url: str = os.getenv("DATALINKER_CUTOUT_SYNC_URL", "")
+    """The URL to the sync API for the SODA service that does cutouts.
+
+    Set with the ``DATALINKER_CUTOUT_SYNC_URL`` environment variable.
+    """
+
     name: str = os.getenv("SAFIR_NAME", "datalinker")
     """The application's name, which doubles as the root HTTP endpoint path.
 

--- a/src/datalinker/handlers/external.py
+++ b/src/datalinker/handlers/external.py
@@ -238,7 +238,7 @@ async def links(
         "SODA image cutout service",
         "#cutout",
         "application/fits",
-        None,
+        0,
     )
 
     # Add resource containing SODA descriptor for cutout service

--- a/src/datalinker/templates/links.xml
+++ b/src/datalinker/templates/links.xml
@@ -18,7 +18,7 @@
           name="semantics" ucd="meta.code"/>
    <FIELD ID="content_type" arraysize="*" datatype="char"
           name="content_type" ucd="meta.code.mime"/>
-   <FIELD ID="content_length" arraysize="1" datatype="long"
+   <FIELD ID="content_length" datatype="long"
           name="content_length" ucd="phys.size;meta.file" unit="byte"/>
    <DATA>
     <TABLEDATA>

--- a/src/datalinker/templates/links.xml
+++ b/src/datalinker/templates/links.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/VOTable-1.4.xsd">
+ <RESOURCE type="results">
+  <TABLE>
+   <FIELD ID="ID" arraysize="*" datatype="char"
+          name="ID" ucd="meta.id;meta.main"/>
+   <FIELD ID="access_url" arraysize="*" datatype="char"
+          name="access_url" ucd="meta.ref.url"/>
+   <FIELD ID="service_def" arraysize="*" datatype="char"
+          name="service_def" ucd="meta.ref"/>
+   <FIELD ID="error_message" arraysize="*" datatype="char"
+          name="error_message" ucd="meta.code.error"/>
+   <FIELD ID="description" arraysize="*" datatype="char"
+          name="description" ucd="meta.note"/>
+   <FIELD ID="semantics" arraysize="*" datatype="char"
+          name="semantics" ucd="meta.code"/>
+   <FIELD ID="content_type" arraysize="*" datatype="char"
+          name="content_type" ucd="meta.code.mime"/>
+   <FIELD ID="content_length" arraysize="1" datatype="long"
+          name="content_length" ucd="phys.size;meta.file" unit="byte"/>
+   <DATA>
+    <TABLEDATA>
+     <TR>
+      <TD>{{ id }}</TD>
+      <TD><![CDATA[{{ image_url | safe }}]]></TD>
+      <TD/>
+      <TD/>
+      <TD>Primary image or observation data file</TD>
+      <TD>#this</TD>
+      <TD>application/fits</TD>
+      <TD>{{ image_size }}</TD>
+     </TR>
+     <TR>
+      <TD>{{ id }}</TD>
+      <TD/>
+      <TD>cutout-sync</TD>
+      <TD/>
+      <TD>SODA image cutout service</TD>
+      <TD>#cutout</TD>
+      <TD>application/fits</TD>
+      <TD/>
+     </TR>
+    </TABLEDATA>
+   </DATA>
+  </TABLE>
+ </RESOURCE>
+ <RESOURCE ID="cutout-sync" type="meta" utype="adhoc:service">
+   <GROUP name="inputParams">
+     <PARAM arraysize="*" datatype="char" name="ID" ucd="meta.id;meta.main" 
+            value="{{ id }}">
+       <DESCRIPTION>Publisher DID of the dataset of interest</DESCRIPTION>
+     </PARAM>
+     <PARAM arraysize="*" datatype="double" name="POLYGON" 
+            ucd="pos.outline;obs" unit="deg" value="">
+       <DESCRIPTION>A polygon (as a flattened array of ra, dec pairs) that 
+         should be covered by the cutout.</DESCRIPTION>
+     </PARAM>
+     <PARAM arraysize="3" datatype="double" name="CIRCLE" 
+            ucd="pos.outline;obs" unit="deg" value="">
+       <DESCRIPTION>A circle (as a flattened array of ra, dec, radius) 
+         that should be covered by the cutout.</DESCRIPTION>
+     </PARAM>
+   </GROUP>
+   <PARAM arraysize="*" datatype="char" name="accessURL" ucd="meta.ref.url" 
+          value="{{ cutout_url }}"/>
+   <PARAM arraysize="*" datatype="char" name="standardID" 
+          value="ivo://ivoa.net/std/SODA#sync-1.0"/>
+ </RESOURCE>
+</VOTABLE>


### PR DESCRIPTION
astropy is missing too many features and is too awkward to use to
construct the datalink VOTable.  Use Jinja2 templated XML instead.

Make the links handler non-async since it's calling a bunch of
non-async Butler code under the hood and needs to use a thread
pool.

Add a service_ref row and a resource for the sync version of the
cutout service to the links returned for an image.