### PR TITLE
DM-35181: Added DALI xtypes to SODA service descriptors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,17 @@
 datalinker
 ##########
 
-Provides Datalink rewriting to help with linking data from the TAP service
+Provides two capabilities for the Rubin Science Platform based on the IVOA DataLink standard:
+
+- Implements a "links" endpoint, providing a variety of file and service links given an ID
+  for an image in the RSP image services.  This endpoint is the target of the ``access_url``
+  column in the RSP ObsTAP service.
+
+- Implements a variety of "microservice" endpoints to be used as the targets of DataLink
+  service descriptors, many of which will rewrite simple service-descriptor-friendly
+  URL APIs into more complicated queries to a back end.  Some of these will be associated
+  with entries in the tables from the "links" endpoint for images; some will be used with
+  service descriptors in catalog query results.
 
 datalinker is developed with the `Safir <https://safir.lsst.io>`__ framework.
 `Get started with development with the tutorial <https://safir.lsst.io/set-up-from-template.html>`__.

--- a/src/datalinker/templates/links.xml
+++ b/src/datalinker/templates/links.xml
@@ -54,12 +54,12 @@
        <DESCRIPTION>Publisher DID of the dataset of interest</DESCRIPTION>
      </PARAM>
      <PARAM arraysize="*" datatype="double" name="POLYGON" 
-            ucd="pos.outline;obs" unit="deg" value="">
+            ucd="pos.outline;obs" unit="deg" value="" xtype="polygon">
        <DESCRIPTION>A polygon (as a flattened array of ra, dec pairs) that 
          should be covered by the cutout.</DESCRIPTION>
      </PARAM>
      <PARAM arraysize="3" datatype="double" name="CIRCLE" 
-            ucd="pos.outline;obs" unit="deg" value="">
+            ucd="pos.outline;obs" unit="deg" value="" xtype="circle">
        <DESCRIPTION>A circle (as a flattened array of ra, dec, radius) 
          that should be covered by the cutout.</DESCRIPTION>
      </PARAM>


### PR DESCRIPTION
Based on CADC practice, the SODA and DALI standards, and a clarification of intent in the DataLink 1.1 draft.  Enables clients to explicitly determine that a param really is intended to be a circle / polygon rather than inferring it.

Required for DP0.2.