### PR TITLE
[DM-35182] Add robustness and a test suite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,15 +4,18 @@ datalinker
 
 Provides two capabilities for the Rubin Science Platform based on the IVOA DataLink standard:
 
-- Implements a "links" endpoint, providing a variety of file and service links given an ID
-  for an image in the RSP image services.  This endpoint is the target of the ``access_url``
-  column in the RSP ObsTAP service.
+- Implements a "links" endpoint, providing a variety of file and service links given an ID for an image in the RSP image services.
+  This endpoint is the target of the ``access_url`` column in the RSP ObsTAP service.
 
-- Implements a variety of "microservice" endpoints to be used as the targets of DataLink
-  service descriptors, many of which will rewrite simple service-descriptor-friendly
-  URL APIs into more complicated queries to a back end.  Some of these will be associated
-  with entries in the tables from the "links" endpoint for images; some will be used with
-  service descriptors in catalog query results.
+- Implements a variety of "microservice" endpoints to be used as the targets of DataLink service descriptors, many of which will rewrite simple service-descriptor-friendly URL APIs into more complicated queries to a back end.
+  Some of these will be associated with entries in the tables from the "links" endpoint for images; some will be used with service descriptors in catalog query results.
+
+datalinker implements `version 1.0 of the IVOA DataLink standard <https://www.ivoa.net/documents/DataLink/20150617/REC-DataLink-1.0-20150617.html>`__ with the following known exceptions:
+
+- The ``content`` parameter is not set in the MIME type of the reply.
+- The links endpoing only supports ``GET``, not ``POST``.
+- ``/availability`` and ``/capabilities`` are not yet implemented.
+- Errors are formatted as JSON rather than as VOTables.
 
 datalinker is developed with the `Safir <https://safir.lsst.io>`__ framework.
 `Get started with development with the tutorial <https://safir.lsst.io/set-up-from-template.html>`__.

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -16,6 +16,6 @@ jinja2
 safir
 
 # lsst.daf.butler is not yet on PyPI
-git+https://github.com/lsst/daf_butler.git@main#daf_butler
+git+https://github.com/lsst/daf_butler.git@main#lsst-daf-butler
 boto3
 psycopg2

--- a/src/datalinker/handlers/external.py
+++ b/src/datalinker/handlers/external.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Literal
 from urllib.parse import urlencode, urlparse
 from uuid import UUID
 
@@ -111,6 +111,9 @@ def links(
         title="Object ID",
         example="butler://dp02/58f56d2e-cfd8-44e7-a343-20ebdc1f4127",
         regex="^butler://[^/]+/[a-f0-9-]+$",
+    ),
+    responseformat: Literal["votable", "application/x-votable+xml"] = Query(
+        "application/x-votable+xml", title="Response format"
     ),
     logger: BoundLogger = Depends(logger_dependency),
 ) -> Response:

--- a/src/datalinker/handlers/external.py
+++ b/src/datalinker/handlers/external.py
@@ -6,11 +6,11 @@ from typing import Dict
 from urllib.parse import urlparse
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 from google.cloud import storage
-from lsst.daf.butler import Butler
+from lsst.daf import butler
 from safir.dependencies.logger import logger_dependency
 from safir.metadata import get_metadata
 from structlog.stdlib import BoundLogger
@@ -21,19 +21,42 @@ from ..models import Index
 external_router = APIRouter()
 """FastAPI router for all external handlers."""
 
-_templates = Jinja2Templates(
+_BUTLER_CACHE: Dict[str, butler.Butler] = {}
+"""Cache of Butlers by label."""
+
+_TEMPLATES = Jinja2Templates(
     directory=str(Path(__file__).parent.parent / "templates")
 )
+"""FastAPI renderer for templated responses."""
 
 __all__ = ["get_index", "external_router"]
 
 
+def _get_butler(label: str) -> butler.Butler:
+    """Retrieve a cached Butler object or create a new one.
+
+    Don't bother adding a lock in, it's fine to make a couple if there's a
+    race condition, they'll get cleaned up.
+
+    Parameters
+    ----------
+    label : `str`
+        Label identifying the Butler repository.
+
+    Returns
+    -------
+    butler : `lsst.daf.butler.Butler`
+        Corresponding Butler.
+    """
+    global _BUTLER_CACHE
+
+    if label not in _BUTLER_CACHE:
+        _BUTLER_CACHE[label] = butler.Butler(label)
+    return _BUTLER_CACHE[label]
+
+
 @external_router.get(
     "/",
-    description=(
-        "Document the top-level API here. By default it only returns metadata"
-        " about the application."
-    ),
     response_model=Index,
     response_model_exclude_none=True,
     summary="Application metadata",
@@ -43,20 +66,10 @@ async def get_index(
 ) -> Index:
     """GET ``/datalinker/`` (the app's external root).
 
-    Customize this handler to return whatever the top-level resource of your
-    application should return. For example, consider listing key API URLs.
-    When doing so, also change or customize the response model in
-    `datalinker.models.Index`.
-
     By convention, the root of the external API includes a field called
     ``metadata`` that provides the same Safir-generated metadata as the
     internal root endpoint.
     """
-    # There is no need to log simple requests since uvicorn will do this
-    # automatically, but this is included as an example of how to use the
-    # logger for more complex logging.
-    logger.info("Request for application metadata")
-
     metadata = get_metadata(
         package_name="datalinker",
         application_name=config.name,
@@ -87,23 +100,11 @@ async def cone_search(
     return url
 
 
-_butler_cache: Dict[str, Butler] = dict()
-
-
-def retrieve_butler(label: str) -> Butler:
-    # Best effort to cache butler objects.
-    # Don't bother adding a lock in, it's fine to make
-    # a couple if there's a race condition, they'll get
-    # cleaned up.
-    if label in _butler_cache:
-        return _butler_cache[label]
-
-    b = Butler(label)
-    _butler_cache[label] = b
-    return b
-
-
-@external_router.get("/links")
+@external_router.get(
+    "/links",
+    responses={404: {"description": "Specified identifier not found"}},
+    summary="DataLink links for object",
+)
 def links(
     id: str,
     request: Request,
@@ -112,23 +113,28 @@ def links(
     # Parse the "butler://label/uuid" ID URI
     butler_uri = urlparse(id)
     label = butler_uri.netloc
-    uuid_str = butler_uri.path[1:]
-    logger.info(f"Loading {label} {uuid_str}")
-
-    uuid = UUID(uuid_str)
-    butler = retrieve_butler(label)
+    uuid = butler_uri.path[1:]
+    logger.debug(f"Loading {label} {uuid}")
 
     # This returns lsst.resources.ResourcePath
-    ref = butler.registry.getDataset(uuid)
+    butler = _get_butler(label)
+    ref = butler.registry.getDataset(UUID(uuid))
     if not ref:
-        logger.error("Dataset does not exist")
-        image_uri = None
-    else:
-        image_uri = butler.datastore.getURI(ref)
+        logger.warning("Dataset does not exist", id=id)
+        raise HTTPException(
+            status_code=404,
+            detail=[
+                {
+                    "loc": ["query", "id"],
+                    "msg": f"Dataset {id} does not exist",
+                    "type": "not_found",
+                }
+            ],
+        )
+    image_uri = butler.datastore.getURI(ref)
+    logger.debug(f"Image URI is: {image_uri}")
 
-    logger.info(f"Image_uri is: {image_uri}")
-
-    # Generate signed URL
+    # Generate signed URL.
     image_uri_parts = urlparse(str(image_uri))
     storage_client = storage.Client()
     bucket = storage_client.bucket(image_uri_parts.netloc)
@@ -138,20 +144,16 @@ def links(
         version="v4",
         # This URL is valid for one hour.
         expiration=timedelta(hours=1),
-        # Allow GET requests using this URL.
+        # Allow only GET requests using this URL.
         method="GET",
     )
 
-    image_size = 0
-    if image_uri:
-        image_size = image_uri.size()
-
-    return _templates.TemplateResponse(
+    return _TEMPLATES.TemplateResponse(
         "links.xml",
         {
             "id": id,
             "image_url": signed_url,
-            "image_size": image_size,
+            "image_size": image_uri.size(),
             "cutout_url": config.cutout_url,
             "request": request,
         },

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -95,6 +95,18 @@ async def test_links(
     )
     assert r.text == expected
 
+    # Check the same with explicit RESPONSEFORMAT.
+    for response_format in ("votable", "application/x-votable+xml"):
+        r = await client.get(
+            "/api/datalink/links",
+            params={
+                "iD": f"butler://label/{str(mock_butler.uuid)}",
+                "responseformat": response_format,
+            },
+        )
+        assert r.status_code == 200
+        assert r.text == expected
+
 
 @pytest.mark.asyncio
 async def test_links_errors(
@@ -113,6 +125,16 @@ async def test_links_errors(
     for test_id in ("butler://", "butler://test-butler", "blah-blah"):
         r = await client.get("/api/datalink/links", params={"id": test_id})
         assert r.status_code == 422
+
+    # Test invalid RESPONSEFORMAT.
+    r = await client.get(
+        "/api/datalink/links",
+        params={
+            "id": f"butler://test-butler/{str(uuid)}",
+            "responseformat": "text/plain",
+        },
+    )
+    assert r.status_code == 422
 
 
 @pytest.mark.asyncio

--- a/tests/support/butler.py
+++ b/tests/support/butler.py
@@ -1,0 +1,49 @@
+"""Mock Butler for testing."""
+
+from __future__ import annotations
+
+from typing import Any, Iterator, Optional
+from unittest.mock import Mock, patch
+from uuid import UUID, uuid4
+
+from lsst.daf import butler
+
+__all__ = ["MockButler", "patch_butler"]
+
+
+class MockResourcePath:
+    """Mock version of `lsst.resources.ResourcePath` for testing."""
+
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+    def __str__(self) -> str:
+        return self.url
+
+    def size(self) -> int:
+        """Returns a fairly random number for testing."""
+        return len(self.url) * 10
+
+
+class MockButler(Mock):
+    """Mock of Butler for testing."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(spec=butler.Butler, **kwargs)
+        self.uuid = uuid4()
+        self.registry = self
+        self.datastore = self
+
+    def getDataset(self, uuid: UUID) -> Optional[UUID]:
+        return uuid if uuid == self.uuid else None
+
+    def getURI(self, ref: UUID) -> MockResourcePath:
+        return MockResourcePath(f"s3://some-bucket/{str(ref)}")
+
+
+def patch_butler() -> Iterator[MockButler]:
+    """Mock out Butler for testing."""
+    mock_butler = MockButler()
+    with patch.object(butler, "Butler") as mock:
+        mock.return_value = mock_butler
+        yield mock_butler

--- a/tests/support/gcs.py
+++ b/tests/support/gcs.py
@@ -1,0 +1,45 @@
+"""Mock Google Cloud Storage API for testing."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, Optional
+from unittest.mock import Mock
+
+from google.cloud import storage
+
+
+class MockBlob(Mock):
+    def __init__(self, name: str) -> None:
+        super().__init__(spec=storage.blob.Blob)
+        self.name = name
+
+    def generate_signed_url(
+        self,
+        *,
+        version: str,
+        expiration: timedelta,
+        method: str,
+        response_type: Optional[str] = None,
+        credentials: Optional[Any] = None,
+    ) -> str:
+        assert version == "v4"
+        assert expiration == timedelta(hours=1)
+        assert method == "GET"
+        return f"https://example.com/{self.name}"
+
+
+class MockBucket(Mock):
+    def __init__(self) -> None:
+        super().__init__(spec=storage.bucket.Bucket)
+
+    def blob(self, blob_name: str) -> Mock:
+        return MockBlob(blob_name)
+
+
+class MockStorageClient(Mock):
+    def __init__(self) -> None:
+        super().__init__(spec=storage.Client)
+
+    def bucket(self, bucket_name: str) -> Mock:
+        return MockBucket()

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     -r{toxinidir}/requirements/main.txt
     -r{toxinidir}/requirements/dev.txt
 commands =
-    pytest --cov=datalinker --cov-branch --cov-report= {posargs}
+    pytest -vvv --cov=datalinker --cov-branch --cov-report= {posargs}
 
 [testenv:coverage-report]
 description = Compile coverage from each test run.


### PR DESCRIPTION
- Validate the parameters to cone search and use URL escaping functions
- Support `RESPONSEFORMAT` argument to the links endpoint
- Return 404 errors for invalid IDs instead of partial data
- Return 404 errors for invalid Butler labels
- Validate the id parameter to the links endpoint
- Add a test suite with a mock Butler and mock Google Cloud Storage
- Improve the route annotations for better OpenAPI documentation
- Document the remaining known gaps from the standard
- Minor cleanup here and there