### PR TITLE
[DM-35253] Don't return cutout service_ref for raws

### DIFF
--- a/src/datalinker/handlers/external.py
+++ b/src/datalinker/handlers/external.py
@@ -162,7 +162,6 @@ def links(
     storage_client = storage.Client()
     bucket = storage_client.bucket(image_uri_parts.netloc)
     blob = bucket.blob(image_uri_parts.path[1:])
-
     signed_url = blob.generate_signed_url(
         version="v4",
         # This URL is valid for one hour.
@@ -174,6 +173,7 @@ def links(
     return _TEMPLATES.TemplateResponse(
         "links.xml",
         {
+            "cutout": ref.datasetType.name != "raw",
             "id": id,
             "image_url": signed_url,
             "image_size": image_uri.size(),

--- a/src/datalinker/templates/links.xml
+++ b/src/datalinker/templates/links.xml
@@ -33,6 +33,7 @@
       <TD>application/fits</TD>
       <TD>{{ image_size }}</TD>
      </TR>
+     {%- if cutout %}
      <TR>
       <TD>{{ id }}</TD>
       <TD/>
@@ -43,10 +44,12 @@
       <TD>application/fits</TD>
       <TD/>
      </TR>
+     {%- endif %}
     </TABLEDATA>
    </DATA>
   </TABLE>
  </RESOURCE>
+ {%- if cutout %}
  <RESOURCE ID="cutout-sync" type="meta" utype="adhoc:service">
    <GROUP name="inputParams">
      <PARAM arraysize="*" datatype="char" name="ID" ucd="meta.id;meta.main" 
@@ -69,4 +72,5 @@
    <PARAM arraysize="*" datatype="char" name="standardID" 
           value="ivo://ivoa.net/std/SODA#sync-1.0"/>
  </RESOURCE>
+ {%- endif %}
 </VOTABLE>

--- a/tests/support/butler.py
+++ b/tests/support/butler.py
@@ -25,20 +25,34 @@ class MockResourcePath:
         return len(self.url) * 10
 
 
+class MockDatasetRef:
+    """Mock of a Butler DatasetRef."""
+
+    def __init__(self, uuid: UUID, dataset_type: str) -> None:
+        self.uuid = uuid
+        self.datasetType = self
+        self.name = dataset_type
+
+
 class MockButler(Mock):
     """Mock of Butler for testing."""
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(spec=butler.Butler, **kwargs)
         self.uuid = uuid4()
+        self.is_raw = False
         self.registry = self
         self.datastore = self
 
-    def getDataset(self, uuid: UUID) -> Optional[UUID]:
-        return uuid if uuid == self.uuid else None
+    def getDataset(self, uuid: UUID) -> Optional[MockDatasetRef]:
+        dataset_type = "raw" if self.is_raw else "calexp"
+        if uuid == self.uuid:
+            return MockDatasetRef(uuid, dataset_type)
+        else:
+            return None
 
-    def getURI(self, ref: UUID) -> MockResourcePath:
-        return MockResourcePath(f"s3://some-bucket/{str(ref)}")
+    def getURI(self, ref: MockDatasetRef) -> MockResourcePath:
+        return MockResourcePath(f"s3://some-bucket/{str(ref.uuid)}")
 
 
 def patch_butler() -> Iterator[MockButler]:


### PR DESCRIPTION
Raw images aren't supported by the cutout service.  Detect those
with the Butler DatasetRef and exclude the cutout service_ref from
the returned links table.

This is a stopgap solution for DP0.2 until we design a more modular
architecture and decide how much information we want to encode in
the obstap table.