### PR TITLE
Use meta.id;meta.dataset for SODA ID parameter

### DIFF
--- a/src/datalinker/templates/links.xml
+++ b/src/datalinker/templates/links.xml
@@ -52,24 +52,24 @@
  {%- if cutout %}
  <RESOURCE ID="cutout-sync" type="meta" utype="adhoc:service">
    <GROUP name="inputParams">
-     <PARAM arraysize="*" datatype="char" name="ID" ucd="meta.id;meta.main" 
+     <PARAM arraysize="*" datatype="char" name="ID" ucd="meta.id;meta.dataset"
             value="{{ id }}">
        <DESCRIPTION>Publisher DID of the dataset of interest</DESCRIPTION>
      </PARAM>
-     <PARAM arraysize="*" datatype="double" name="POLYGON" 
+     <PARAM arraysize="*" datatype="double" name="POLYGON"
             ucd="pos.outline;obs" unit="deg" value="" xtype="polygon">
-       <DESCRIPTION>A polygon (as a flattened array of ra, dec pairs) that 
+       <DESCRIPTION>A polygon (as a flattened array of ra, dec pairs) that
          should be covered by the cutout.</DESCRIPTION>
      </PARAM>
-     <PARAM arraysize="3" datatype="double" name="CIRCLE" 
+     <PARAM arraysize="3" datatype="double" name="CIRCLE"
             ucd="pos.outline;obs" unit="deg" value="" xtype="circle">
-       <DESCRIPTION>A circle (as a flattened array of ra, dec, radius) 
+       <DESCRIPTION>A circle (as a flattened array of ra, dec, radius)
          that should be covered by the cutout.</DESCRIPTION>
      </PARAM>
    </GROUP>
-   <PARAM arraysize="*" datatype="char" name="accessURL" ucd="meta.ref.url" 
+   <PARAM arraysize="*" datatype="char" name="accessURL" ucd="meta.ref.url"
           value="{{ cutout_url }}"/>
-   <PARAM arraysize="*" datatype="char" name="standardID" 
+   <PARAM arraysize="*" datatype="char" name="standardID"
           value="ivo://ivoa.net/std/SODA#sync-1.0"/>
  </RESOURCE>
  {%- endif %}


### PR DESCRIPTION
SODA 1.0 errata 1 says that the ID parameter should have type
meta.id;meta.dataset.  This is different than the type of the
exact same parameter in the main links table (meta.id;meta.main),
and I can't find any explanation of why, but it also looks like it
shouldn't matter too much given the discussion in the errata.
Therefore, go with the SODA standard over copying the data type
from the DataLink standard.