### PR TITLE
DM-37516: Update typing and docstrings

### DIFF
--- a/src/datalinker/dependencies/hips.py
+++ b/src/datalinker/dependencies/hips.py
@@ -51,9 +51,9 @@ class HiPSListDependency:
 
         Parameters
         ----------
-        client : `httpx.AsyncClient`
+        client
             Client to use to retrieve the HiPS lists.
-        logger : `structlog.stdlib.BoundLogger`
+        logger
             Logger for any error messages.
         """
         lists = []

--- a/src/datalinker/dependencies/tap.py
+++ b/src/datalinker/dependencies/tap.py
@@ -1,13 +1,13 @@
 """Dependency that caches information about the TAP schema."""
 
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
 import yaml
 
 from ..config import config
 
-TAPMetadata = Dict[str, Dict[str, List[str]]]
+TAPMetadata = dict[str, dict[str, list[str]]]
 
 __all__ = [
     "TAPMetadata",
@@ -36,7 +36,7 @@ class TAPMetadataDependency:
 
         Returns
         -------
-        columns : Dict[`str`, Dict[`str`, List[`str`]]]
+        dict of str to dict of str to list of str
             Mapping from table names (qualified with the schema name) to a
             mapping from column types (``tap:principal`` or ``lsst:minimal``)
             to a list of columns.

--- a/src/datalinker/handlers/external.py
+++ b/src/datalinker/handlers/external.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from email.message import Message
 from importlib.metadata import metadata
 from pathlib import Path
-from typing import Dict, Literal, Optional, cast
+from typing import Literal, Optional, cast
 from urllib.parse import urlencode, urlparse
 from uuid import UUID
 
@@ -29,7 +29,7 @@ from ..models import Band, Detail, Index
 external_router = APIRouter()
 """FastAPI router for all external handlers."""
 
-_BUTLER_CACHE: Dict[str, butler.Butler] = {}
+_BUTLER_CACHE: dict[str, butler.Butler] = {}
 """Cache of Butlers by label."""
 
 _TEMPLATES = Jinja2Templates(
@@ -45,14 +45,14 @@ def _create_tap_redirect(sql: str, logger: BoundLogger) -> str:
 
     Parameters
     ----------
-    sql : `str`
+    sql
         SQL to run, with all parameters already filled in.
-    logger : `structlog.stdlib.BoundLogger`
+    logger
         Logger to log the redirect action.
 
     Returns
     -------
-    url : `str`
+    str
         URL to execute a synchronous TAP query.
     """
     params = {"LANG": "ADQL", "REQUEST": "doQuery", "QUERY": sql}
@@ -69,12 +69,12 @@ def _get_butler(label: str) -> butler.Butler:
 
     Parameters
     ----------
-    label : `str`
+    label
         Label identifying the Butler repository.
 
     Returns
     -------
-    butler : `lsst.daf.butler.Butler`
+    lsst.daf.butler.Butler
         Corresponding Butler.
     """
     global _BUTLER_CACHE
@@ -89,16 +89,16 @@ def _get_tap_columns(table: str, detail: Detail, metadata: TAPMetadata) -> str:
 
     Parameters
     ----------
-    table : `str`
+    table
         Fully-qualified name of the table.
-    detail : `datalinker.models.Detail`
+    detail
         Level of detail desired.
-    metadata : `datalinker.dependencies.tap.TAPMetadata`
+    metadata
         Cached TAP table metadata.
 
     Returns
     -------
-    columns : `str`
+    str
         The SQL expresion for columns to retrieve.
     """
     columns_str = "s.*"

--- a/src/datalinker/handlers/internal.py
+++ b/src/datalinker/handlers/internal.py
@@ -8,12 +8,10 @@ These handlers should be used for monitoring, health checks, internal status,
 or other information that should not be visible outside the Kubernetes cluster.
 """
 
-from email.message import Message
-from importlib.metadata import metadata
-from typing import cast
-
 from fastapi import APIRouter
-from safir.metadata import Metadata, get_project_url
+from safir.metadata import Metadata, get_metadata
+
+from ..config import config
 
 __all__ = ["get_index", "internal_router"]
 
@@ -28,6 +26,7 @@ internal_router = APIRouter()
         " a health check. This route is not exposed outside the cluster and"
         " therefore cannot be used by external clients."
     ),
+    include_in_schema=False,
     response_model=Metadata,
     response_model_exclude_none=True,
     summary="Application metadata",
@@ -37,11 +36,6 @@ async def get_index() -> Metadata:
 
     By convention, this endpoint returns only the application's metadata.
     """
-    pkg_metadata = cast(Message, metadata("datalinker"))
-    return Metadata(
-        name="datalinker",
-        version=pkg_metadata["Version"],
-        description=pkg_metadata["Summary"],
-        repository_url=get_project_url(pkg_metadata, "Source"),
-        documentation_url=get_project_url(pkg_metadata, "Homepage"),
+    return get_metadata(
+        package_name="datalinker", application_name=config.name
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator, Iterator
 from datetime import timedelta
 from pathlib import Path
-from typing import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
+from httpx import AsyncClient
 
 from datalinker.config import config
-
-if TYPE_CHECKING:
-    from httpx import AsyncClient
 
 
 @pytest.mark.asyncio

--- a/tests/support/butler.py
+++ b/tests/support/butler.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterator, Optional
+from collections.abc import Iterator
+from typing import Any
 from unittest.mock import Mock, patch
 from uuid import UUID, uuid4
 
@@ -37,14 +38,17 @@ class MockDatasetRef:
 class MockButler(Mock):
     """Mock of Butler for testing."""
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(spec=butler.Butler, **kwargs)
+    def __init__(self) -> None:
+        super().__init__(spec=butler.Butler)
         self.uuid = uuid4()
         self.is_raw = False
         self.registry = self
         self.datastore = self
 
-    def getDataset(self, uuid: UUID) -> Optional[MockDatasetRef]:
+    def _get_child_mock(self, /, **kwargs: Any) -> Mock:
+        return Mock(**kwargs)
+
+    def getDataset(self, uuid: UUID) -> MockDatasetRef | None:
         dataset_type = "raw" if self.is_raw else "calexp"
         if uuid == self.uuid:
             return MockDatasetRef(uuid, dataset_type)


### PR DESCRIPTION
Fix the deprecations in PEP 585, and use the | syntax instead of Union and some Optional cases.  Drop unnecessary types from docstrings.