### PR TITLE
DM-42660: Use Butler repository list from environment var

### DIFF
--- a/scripts/start-frontend.sh
+++ b/scripts/start-frontend.sh
@@ -6,7 +6,7 @@ if [ -n "$DATALINKER_TAP_METADATA_URL" ]; then
         exit 1
     fi
     curl -L "$DATALINKER_TAP_METADATA_URL" -o /tmp/datalink-columns.zip
-    unzip /tmp/datalink-columns.zip -d "$DATALINKER_TAP_METADATA_DIR"
+    unzip -o /tmp/datalink-columns.zip -d "$DATALINKER_TAP_METADATA_DIR"
 fi
 
 rm -rf /tmp/secrets

--- a/src/datalinker/config.py
+++ b/src/datalinker/config.py
@@ -3,9 +3,19 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+from pydantic import TypeAdapter
 
 __all__ = ["Configuration", "config"]
+
+
+def _get_butler_repositories() -> dict[str, str] | None:
+    json = os.getenv("DAF_BUTLER_REPOSITORIES", None)
+    if json is not None:
+        return TypeAdapter(dict[str, str]).validate_json(json)
+
+    return None
 
 
 @dataclass
@@ -74,6 +84,18 @@ class Configuration:
     """The S3 endpoint URL to use.
 
     Set with the ``S3_ENDPOINT_URL`` environment variable.
+    """
+
+    # TODO DM-42660: butler_repositories can be removed once there is a release
+    # of daf_butler available that handles DAF_BUTLER_REPOSITORIES itself.
+    butler_repositories: dict[str, str] | None = field(
+        default_factory=_get_butler_repositories
+    )
+    """Mapping from label to URI for Butler repositories used by this service.
+
+    Set with the ``DAF_BUTLER_REPOSITORIES`` environment variable.  If not set,
+    Butler will fall back to looking this up from a file whose URI is given in
+    the ``DAF_BUTLER_REPOSITORY_INDEX`` environment variable.
     """
 
 

--- a/src/datalinker/handlers/external.py
+++ b/src/datalinker/handlers/external.py
@@ -31,7 +31,7 @@ from ..models import Band, Detail, Index
 external_router = APIRouter()
 """FastAPI router for all external handlers."""
 
-_BUTLER_FACTORY = LabeledButlerFactory()
+_BUTLER_FACTORY = LabeledButlerFactory(config.butler_repositories)
 """Factory for creating Butlers from a label and Gafaelfawr token."""
 
 _TEMPLATES = Jinja2Templates(


### PR DESCRIPTION
Instead of always requiring a file to exist containing the list of Butler repositories, optionally read it from an environment variable.  Equivalent functionality will be added to daf_butler itself shortly, but I don't want to wait another week to get this deployed.

Also fixed a small bug where `unzip` would interactively prompt to overwrite files if the service crashes on startup, preventing you from seeing the error message from the crash in the logs.