### PR TITLE
DM-42689: Configure Uvicorn logging

### DIFF
--- a/changelog.d/20240126_143234_rra_DM_42689.md
+++ b/changelog.d/20240126_143234_rra_DM_42689.md
@@ -1,0 +1,3 @@
+### New features
+
+- Configure Uvicorn to log accesses in a JSON format if datalinker is configured to use the production logging profile.

--- a/src/datalinker/main.py
+++ b/src/datalinker/main.py
@@ -13,7 +13,7 @@ from importlib.metadata import metadata, version
 
 from fastapi import FastAPI
 from safir.dependencies.http_client import http_client_dependency
-from safir.logging import configure_logging
+from safir.logging import Profile, configure_logging, configure_uvicorn_logging
 from safir.middleware.ivoa import CaseInsensitiveQueryMiddleware
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
@@ -36,6 +36,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 configure_logging(
     profile=config.profile, log_level=config.log_level, name="datalinker"
 )
+if config.profile == Profile.production:
+    configure_uvicorn_logging(config.log_level)
 
 app = FastAPI(
     title="datalinker",


### PR DESCRIPTION
If using the production logging profile, also configure Uvicorn logging to use JSON and honor the configured log level.