### PR TITLE
DM-42689: Add support for reporting uncaught exceptions

### DIFF
--- a/changelog.d/20240126_144524_rra_DM_42689.md
+++ b/changelog.d/20240126_144524_rra_DM_42689.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add support for reporting uncaught exceptions to a Slack incoming webhook.

--- a/src/datalinker/config.py
+++ b/src/datalinker/config.py
@@ -6,7 +6,7 @@ import os
 from enum import Enum
 from typing import Annotated
 
-from pydantic import Field, TypeAdapter
+from pydantic import Field, HttpUrl, TypeAdapter
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.logging import LogLevel, Profile
 
@@ -122,6 +122,10 @@ class Config(BaseSettings):
             validation_alias="SAFIR_LOG_LEVEL",
         ),
     ] = LogLevel.INFO
+
+    slack_webhook: Annotated[
+        HttpUrl | None, Field(title="Slack webhook for exception reporting")
+    ] = None
 
     model_config = SettingsConfigDict(
         env_prefix="DATALINKER_", case_sensitive=False

--- a/src/datalinker/handlers/external.py
+++ b/src/datalinker/handlers/external.py
@@ -17,6 +17,7 @@ from lsst.daf.butler import LabeledButlerFactory
 from safir.dependencies.gafaelfawr import auth_delegated_token_dependency
 from safir.dependencies.logger import logger_dependency
 from safir.metadata import Metadata, get_project_url
+from safir.slack.webhook import SlackRouteErrorHandler
 from structlog.stdlib import BoundLogger
 
 from ..config import StorageBackend, config
@@ -28,7 +29,7 @@ from ..constants import (
 from ..dependencies.tap import TAPMetadata, tap_metadata_dependency
 from ..models import Band, Detail, Index
 
-external_router = APIRouter()
+external_router = APIRouter(route_class=SlackRouteErrorHandler)
 """FastAPI router for all external handlers."""
 
 _BUTLER_FACTORY = LabeledButlerFactory(config.butler_repositories)

--- a/src/datalinker/handlers/hips.py
+++ b/src/datalinker/handlers/hips.py
@@ -8,10 +8,11 @@ it doesn't require authentication and is served with a different prefix.
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import PlainTextResponse
+from safir.slack.webhook import SlackRouteErrorHandler
 
 from ..dependencies.hips import hips_list_dependency
 
-hips_router = APIRouter()
+hips_router = APIRouter(route_class=SlackRouteErrorHandler)
 """FastAPI router for HiPS handlers."""
 
 __all__ = ["hips_router"]

--- a/src/datalinker/handlers/internal.py
+++ b/src/datalinker/handlers/internal.py
@@ -10,12 +10,13 @@ or other information that should not be visible outside the Kubernetes cluster.
 
 from fastapi import APIRouter
 from safir.metadata import Metadata, get_metadata
+from safir.slack.webhook import SlackRouteErrorHandler
 
 from ..config import config
 
 __all__ = ["get_index", "internal_router"]
 
-internal_router = APIRouter()
+internal_router = APIRouter(route_class=SlackRouteErrorHandler)
 """FastAPI router for all internal handlers."""
 
 

--- a/src/datalinker/main.py
+++ b/src/datalinker/main.py
@@ -11,18 +11,20 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from importlib.metadata import metadata, version
 
+import structlog
 from fastapi import FastAPI
 from safir.dependencies.http_client import http_client_dependency
 from safir.logging import Profile, configure_logging, configure_uvicorn_logging
 from safir.middleware.ivoa import CaseInsensitiveQueryMiddleware
 from safir.middleware.x_forwarded import XForwardedMiddleware
+from safir.slack.webhook import SlackRouteErrorHandler
 
 from .config import config
 from .handlers.external import external_router
 from .handlers.hips import hips_router
 from .handlers.internal import internal_router
 
-__all__ = ["app", "config"]
+__all__ = ["app"]
 
 
 @asynccontextmanager
@@ -58,3 +60,10 @@ app.include_router(hips_router, prefix="/api/hips")
 # Add the middleware.
 app.add_middleware(CaseInsensitiveQueryMiddleware)
 app.add_middleware(XForwardedMiddleware)
+
+# Configure Slack alerts.
+if config.slack_webhook:
+    webhook = str(config.slack_webhook)
+    logger = structlog.get_logger(__name__)
+    SlackRouteErrorHandler.initialize(webhook, config.name, logger)
+    logger.debug("Initialized Slack webhook")


### PR DESCRIPTION
Add a configuration parameter for a Slack incoming webhook and, if set, use it to report uncaught exceptions from route handlers.