### PR TITLE
DM-42689: Allow URL path prefixes to be configured

### DIFF
--- a/changelog.d/20240126_145602_rra_DM_42689.md
+++ b/changelog.d/20240126_145602_rra_DM_42689.md
@@ -1,0 +1,3 @@
+### New features
+
+- Support configuration of the DataLink and HiPS URL prefixes on which datalinker should listen.

--- a/src/datalinker/config.py
+++ b/src/datalinker/config.py
@@ -107,6 +107,25 @@ class Config(BaseSettings):
         ),
     ] = "datalinker"
 
+    path_prefix: Annotated[
+        str,
+        Field(
+            title="URL prefix for DataLink API",
+            description=(
+                "This URL prefix is used for the IVOA DataLink API and for"
+                " any other helper APIs exposed via DataLink descriptors"
+            ),
+        ),
+    ] = "/api/datalink"
+
+    hips_path_prefix: Annotated[
+        str,
+        Field(
+            title="URL prefix for HiPS API",
+            description="URL prefix used to inject the HiPS list file",
+        ),
+    ] = "/api/hips"
+
     profile: Annotated[
         Profile,
         Field(

--- a/src/datalinker/main.py
+++ b/src/datalinker/main.py
@@ -45,17 +45,17 @@ app = FastAPI(
     title="datalinker",
     description=metadata("datalinker")["Summary"],
     version=version("datalinker"),
-    openapi_url="/api/datalink/openapi.json",
-    docs_url="/api/datalink/docs",
-    redoc_url="/api/datalink/redoc",
+    openapi_url=f"{config.path_prefix}/openapi.json",
+    docs_url=f"{config.path_prefix}/docs",
+    redoc_url=f"{config.path_prefix}/redoc",
     lifespan=lifespan,
 )
 """The main FastAPI application for datalinker."""
 
 # Attach the routers.
 app.include_router(internal_router)
-app.include_router(external_router, prefix="/api/datalink")
-app.include_router(hips_router, prefix="/api/hips")
+app.include_router(external_router, prefix=config.path_prefix)
+app.include_router(hips_router, prefix=config.hips_path_prefix)
 
 # Add the middleware.
 app.add_middleware(CaseInsensitiveQueryMiddleware)


### PR DESCRIPTION
Support configuration of the DataLink and HiPS URL prefixes on which datalinker should listen.