### PR TITLE
DM-42689: Tighten configuration settings and validation

### DIFF
--- a/changelog.d/20240126_160310_rra_DM_42689.md
+++ b/changelog.d/20240126_160310_rra_DM_42689.md
@@ -1,0 +1,4 @@
+### New features
+
+- Standardize using a `DATALINKER_` prefix for all environment variables used to configure datalinker.
+- Diagnose more errors in environment variable settings and fail on startup if the configuration is not valid.

--- a/src/datalinker/config.py
+++ b/src/datalinker/config.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import os
 from enum import Enum
+from pathlib import Path
 from typing import Annotated
 
-from pydantic import Field, HttpUrl, TypeAdapter
+from pydantic import Field, HttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.logging import LogLevel, Profile
 
@@ -15,14 +15,6 @@ __all__ = [
     "StorageBackend",
     "config",
 ]
-
-
-def _get_butler_repositories() -> dict[str, str] | None:
-    json = os.getenv("DAF_BUTLER_REPOSITORIES", None)
-    if json is not None:
-        return TypeAdapter(dict[str, str]).validate_json(json)
-
-    return None
 
 
 class StorageBackend(Enum):
@@ -36,26 +28,26 @@ class Config(BaseSettings):
     """Configuration for datalinker."""
 
     cutout_sync_url: Annotated[
-        str,
+        HttpUrl,
         Field(
             title="URL to SODA sync API",
             description=(
                 "URL to the sync API for the SODA service that does cutouts"
             ),
         ),
-    ] = ""
+    ]
 
-    hips_base_url: Annotated[str, Field(title="Base URL for HiPS lists")] = ""
+    hips_base_url: Annotated[HttpUrl, Field(title="Base URL for HiPS lists")]
 
     tap_metadata_dir: Annotated[
-        str,
+        Path | None,
         Field(
             title="Path to TAP YAML metadata",
             description=(
                 "Directory containing YAML metadata files about TAP schema"
             ),
         ),
-    ] = ""
+    ] = None
 
     token: Annotated[
         str,
@@ -63,20 +55,20 @@ class Config(BaseSettings):
             title="Token for API authentication",
             description="Token to use to authenticate to the HiPS service",
         ),
-    ] = ""
+    ]
 
     storage_backend: Annotated[
         StorageBackend,
         Field(
             title="Storage backend",
             description="Which storage backend to use for uploaded files",
-            validation_alias="STORAGE_BACKEND",
         ),
     ] = StorageBackend.GCS
 
     s3_endpoint_url: Annotated[
-        str, Field(title="Storage API URL", validation_alias="S3_ENDPOINT_URL")
-    ] = "https://storage.googleapis.com"
+        HttpUrl,
+        Field(title="Storage API URL", validation_alias="S3_ENDPOINT_URL"),
+    ] = HttpUrl("https://storage.googleapis.com")
 
     # TODO(DM-42660): butler_repositories can be removed once there is a
     # release of daf_butler available that handles DAF_BUTLER_REPOSITORIES
@@ -97,14 +89,7 @@ class Config(BaseSettings):
 
     name: Annotated[
         str,
-        Field(
-            title="Application name",
-            description=(
-                "The application's name, which doubles as the root HTTP"
-                " endpoint path"
-            ),
-            validation_alias="SAFIR_NAME",
-        ),
+        Field(title="Application name"),
     ] = "datalinker"
 
     path_prefix: Annotated[
@@ -130,16 +115,12 @@ class Config(BaseSettings):
         Profile,
         Field(
             title="Application logging profile",
-            validation_alias="SAFIR_PROFILE",
         ),
-    ] = Profile.development
+    ] = Profile.production
 
     log_level: Annotated[
         LogLevel,
-        Field(
-            title="Log level of the application's logger",
-            validation_alias="SAFIR_LOG_LEVEL",
-        ),
+        Field(title="Log level of the application's logger"),
     ] = LogLevel.INFO
 
     slack_webhook: Annotated[

--- a/src/datalinker/dependencies/hips.py
+++ b/src/datalinker/dependencies/hips.py
@@ -58,7 +58,7 @@ class HiPSListDependency:
         """
         lists = []
         for dataset in HIPS_DATASETS:
-            url = config.hips_base_url + f"/{dataset}"
+            url = str(config.hips_base_url).rstrip("/") + f"/{dataset}"
             r = await client.get(
                 url + "/properties",
                 headers={"Authorization": f"bearer {config.token}"},

--- a/src/datalinker/dependencies/tap.py
+++ b/src/datalinker/dependencies/tap.py
@@ -1,6 +1,5 @@
 """Dependency that caches information about the TAP schema."""
 
-from pathlib import Path
 
 import yaml
 
@@ -49,9 +48,9 @@ class TAPMetadataDependency:
         """Load and cache the schema data."""
         if not config.tap_metadata_dir:
             return {}
-        columns: TAPMetadata = {}
 
-        for data_path in Path(config.tap_metadata_dir).iterdir():
+        columns: TAPMetadata = {}
+        for data_path in config.tap_metadata_dir.iterdir():
             if data_path.suffix != ".yaml":
                 continue
             with data_path.open("r") as fh:

--- a/src/datalinker/handlers/external.py
+++ b/src/datalinker/handlers/external.py
@@ -278,7 +278,7 @@ def links(
             "id": id,
             "image_url": image_url,
             "image_size": image_uri.size(),
-            "cutout_sync_url": config.cutout_sync_url,
+            "cutout_sync_url": str(config.cutout_sync_url),
         },
         media_type="application/x-votable+xml",
     )
@@ -332,7 +332,7 @@ def _upload_to_s3(image_uri: str, expiry: timedelta) -> str:
     key = image_uri_parts.path[1:]
 
     s3_client = client(
-        "s3", endpoint_url=config.s3_endpoint_url, region_name="us-east-1"
+        "s3", endpoint_url=str(config.s3_endpoint_url), region_name="us-east-1"
     )
 
     return s3_client.generate_presigned_url(

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,10 @@ deps =
     -r{toxinidir}/requirements/dev.txt
 commands =
     pytest -vvv --cov=datalinker --cov-branch --cov-report= {posargs}
+setenv =
+    DATALINKER_CUTOUT_SYNC_URL = https://example.com/api/cutout
+    DATALINKER_HIPS_BASE_URL = https://example.com/api/hips
+    DATALINKER_TOKEN = some-gafaelfawr-token
 
 [testenv:coverage-report]
 description = Compile coverage from each test run.


### PR DESCRIPTION
Use a DATALINKER_ prefix for all configuration environment variables and stop using SAFIR_ as a prefix for settings that are passed to Safir. Make mandatory environment variables actually mandatory, and set them to dummy values in tox to avoid issues with the test suite. Declare URLs as HttpUrl so that Pydantic will validate them.