### PR TITLE
DM-45137: Run make update-deps in a virtualenv

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -31,12 +31,17 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Update dependencies
-        run: make update-deps
+        run: |
+          pip install --upgrade uv
+          uv venv
+          source .venv/bin/activate
+          make update-deps
+        shell: bash
 
       - name: Run tests in tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ env.PYTHON_VERSION }}
           tox-envs: "lint,typing,py"
           tox-plugins: tox-uv
           use-cache: false


### PR DESCRIPTION
uv refuses to run outside of a virtualenv, so use uv to create one and activate it before running make update-deps. Fix the Python version for running tox in the periodic CI workflow.