### PR TITLE
DM-45137: Stop importing from _pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import boto3
 import pytest
 import pytest_asyncio
-from _pytest.monkeypatch import MonkeyPatch
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -24,7 +23,7 @@ from .support.butler import MockButler, patch_butler
 
 
 @pytest_asyncio.fixture
-async def app(monkeypatch: MonkeyPatch) -> AsyncIterator[FastAPI]:
+async def app(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
@@ -60,7 +59,7 @@ def mock_butler() -> Iterator[MockButler]:
 
 
 @pytest.fixture
-def s3(monkeypatch: MonkeyPatch) -> Iterator[boto3.client]:
+def s3(monkeypatch: pytest.MonkeyPatch) -> Iterator[boto3.client]:
     """Mock out S3 for testing."""
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
@@ -81,7 +80,7 @@ def s3(monkeypatch: MonkeyPatch) -> Iterator[boto3.client]:
 
 @pytest.fixture
 def mock_google_storage(
-    monkeypatch: MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> Iterator[MockStorageClient]:
     """Mock out the Google Cloud Storage API."""
     monkeypatch.setattr(config, "storage_backend", StorageBackend.GCS)

--- a/tests/handlers/hips_test.py
+++ b/tests/handlers/hips_test.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 import respx
-from _pytest.monkeypatch import MonkeyPatch
 from httpx import AsyncClient, Response
 from pydantic import HttpUrl
 
@@ -17,7 +16,9 @@ from datalinker.constants import HIPS_DATASETS
 
 @pytest.mark.asyncio
 async def test_hips_list(
-    client: AsyncClient, respx_mock: respx.Router, monkeypatch: MonkeyPatch
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     hips_list_template = (
         Path(__file__).parent.parent / "data" / "hips-properties"


### PR DESCRIPTION
It's no longer necessary to import types from _pytest. They're all exported by the pytest module now.