### PR TITLE
DM-45137: Enable docstring reformatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,10 +113,11 @@ python_files = ["tests/*.py", "tests/*/*.py"]
 line-length = 79
 target-version = "py312"
 
+[tool.ruff.format]
+docstring-code-format = true
+
 [tool.ruff.lint]
 ignore = [
-    "ANN101",  # self should not have a type annotation
-    "ANN102",  # cls should not have a type annotation
     "ANN401",  # sometimes Any is the right type
     "ARG001",  # unused function arguments are often legitimate
     "ARG002",  # unused method arguments are often legitimate


### PR DESCRIPTION
Ruff now supports reformatting docstrings, but it's disabled by default. Enable it. Also remove exclusions for some deprecated Ruff diagnostics, since they're no longer enabled by default.