### PR TITLE
DM-45137: Fix condition for periodic CI notification

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -47,7 +47,7 @@ jobs:
           use-cache: false
 
       - name: Report status
-        if: always()
+        if: failure()
         uses: ravsamhq/notify-slack-action@v2
         with:
           status: ${{ job.status }}


### PR DESCRIPTION
Avoid using always(), since per the GitHub documentation it can cause weird issues. Switch to failure() instead, since we only want to do notifications on failure.