### PR TITLE
DM-45137: Drop support for direct Butler

### DIFF
--- a/changelog.d/20240705_171637_rra_DM_45137.md
+++ b/changelog.d/20240705_171637_rra_DM_45137.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Drop support for direct Butler and require client/server Butler.

--- a/src/datalinker/config.py
+++ b/src/datalinker/config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
@@ -12,16 +11,8 @@ from safir.logging import LogLevel, Profile
 
 __all__ = [
     "Config",
-    "StorageBackend",
     "config",
 ]
-
-
-class StorageBackend(Enum):
-    """Possible choices for a storage backend."""
-
-    GCS = "GCS"
-    S3 = "S3"
 
 
 class Config(BaseSettings):
@@ -57,19 +48,6 @@ class Config(BaseSettings):
         ),
     ]
 
-    storage_backend: Annotated[
-        StorageBackend,
-        Field(
-            title="Storage backend",
-            description="Which storage backend to use for uploaded files",
-        ),
-    ] = StorageBackend.GCS
-
-    s3_endpoint_url: Annotated[
-        HttpUrl,
-        Field(title="Storage API URL", validation_alias="S3_ENDPOINT_URL"),
-    ] = HttpUrl("https://storage.googleapis.com")
-
     # TODO(DM-42660): butler_repositories can be removed once there is a
     # release of daf_butler available that handles DAF_BUTLER_REPOSITORIES
     # itself.
@@ -87,10 +65,7 @@ class Config(BaseSettings):
         ),
     ] = None
 
-    name: Annotated[
-        str,
-        Field(title="Application name"),
-    ] = "datalinker"
+    name: Annotated[str, Field(title="Application name")] = "datalinker"
 
     path_prefix: Annotated[
         str,
@@ -113,9 +88,7 @@ class Config(BaseSettings):
 
     profile: Annotated[
         Profile,
-        Field(
-            title="Application logging profile",
-        ),
+        Field(title="Application logging profile"),
     ] = Profile.production
 
     log_level: Annotated[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,21 +3,16 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Iterator
-from datetime import timedelta
 from pathlib import Path
 
-import boto3
 import pytest
 import pytest_asyncio
 from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from moto import mock_aws
-from pydantic import HttpUrl
-from safir.testing.gcs import MockStorageClient, patch_google_storage
 
 from datalinker import main
-from datalinker.config import StorageBackend, config
+from datalinker.config import config
 
 from .support.butler import MockButler, patch_butler
 
@@ -55,38 +50,3 @@ async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
 def mock_butler() -> Iterator[MockButler]:
     """Mock Butler for testing."""
     yield from patch_butler()
-
-
-@pytest.fixture
-def s3(monkeypatch: pytest.MonkeyPatch) -> Iterator[boto3.client]:
-    """Mock out S3 for testing."""
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
-    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
-    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
-    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
-    monkeypatch.setattr(config, "storage_backend", StorageBackend.S3)
-    monkeypatch.setattr(
-        config, "s3_endpoint_url", HttpUrl("https://s3.amazonaws.com/bucket")
-    )
-    with mock_aws():
-        yield boto3.client(
-            "s3",
-            endpoint_url=str(config.s3_endpoint_url),
-            region_name="us-east-1",
-        )
-
-
-@pytest.fixture
-def mock_google_storage(
-    monkeypatch: pytest.MonkeyPatch,
-) -> Iterator[MockStorageClient]:
-    """Mock out the Google Cloud Storage API."""
-    monkeypatch.setattr(config, "storage_backend", StorageBackend.GCS)
-    monkeypatch.setattr(
-        config, "s3_endpoint_url", HttpUrl("https://storage.googleapis.com")
-    )
-    yield from patch_google_storage(
-        expected_expiration=timedelta(hours=1),
-        bucket_name="some-bucket",
-    )


### PR DESCRIPTION
Require client/server Butler and remove all of the code for doing our own file upload and URL signing. This massively simplifies the test suite and removes a flaky test with a timing bug. Also drop the configuration settings used only by direct Butler.