### PR TITLE
DM-45137: Switch to a three-stage Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
-# This Dockerfile has four stages:
+# This Dockerfile has three stages:
 #
 # base-image
 #   Updates the base Python image with security patches and common system
 #   packages. This image becomes the base of all other images.
-# dependencies-image
-#   Installs third-party dependencies (requirements/main.txt) into a virtual
-#   environment. This virtual environment is ideal for copying across build
-#   stages.
 # install-image
-#   Installs the app into the virtual environment.
+#   Installs third-party dependencies (requirements/main.txt) and the
+#   application into a virtual environment. This virtual environment is
+#   ideal for copying across build stages.
 # runtime-image
 #   - Copies the virtual environment into place.
 #   - Runs a non-root user.
@@ -20,7 +18,7 @@ FROM python:3.12.4-slim-bookworm as base-image
 COPY scripts/install-base-packages.sh .
 RUN ./install-base-packages.sh && rm ./install-base-packages.sh
 
-FROM base-image AS dependencies-image
+FROM base-image AS install-image
 
 # Install system packages only needed for building dependencies.
 COPY scripts/install-dependency-packages.sh .
@@ -29,8 +27,10 @@ RUN ./install-dependency-packages.sh
 # Create a Python virtual environment
 ENV VIRTUAL_ENV=/opt/venv
 RUN python -m venv $VIRTUAL_ENV
+
 # Make sure we use the virtualenv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 # Put the latest pip and setuptools in the virtualenv
 RUN pip install --upgrade --no-cache-dir pip setuptools wheel
 
@@ -38,11 +38,7 @@ RUN pip install --upgrade --no-cache-dir pip setuptools wheel
 COPY requirements/main.txt ./requirements.txt
 RUN pip install --quiet --no-cache-dir -r requirements.txt
 
-FROM dependencies-image AS install-image
-
-# Use the virtualenv
-ENV PATH="/opt/venv/bin:$PATH"
-
+# Install the application.
 COPY . /workdir
 WORKDIR /workdir
 RUN pip install --no-cache-dir .

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# This script updates packages in the base Docker image that's used by both the
-# build and runtime images, and gives us a place to install additional
+# This script updates packages in the base Docker image that's used by both
+# the build and runtime images, and gives us a place to install additional
 # system-level packages with apt-get.
 #
 # Based on the blog post:
@@ -9,8 +9,7 @@
 
 # Bash "strict mode", to help catch problems and bugs in the shell
 # script. Every bash script you write should include this. See
-# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for
-# details.
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
 # Display each command as it's run.
@@ -26,9 +25,8 @@ apt-get update
 # Install security updates:
 apt-get -y upgrade
 
-# setuptools_scm requires Git.  Butler requires libpq-dev.  TAP schema
-# metadata requires curl and unzip.
-apt-get -y install --no-install-recommends curl git libpq-dev unzip
+# Butler requires libpq-dev. TAP schema metadata requires curl and unzip.
+apt-get -y install --no-install-recommends curl libpq-dev unzip
 
 # Delete cached files we don't need anymore:
 apt-get clean

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -10,8 +10,7 @@
 
 # Bash "strict mode", to help catch problems and bugs in the shell
 # script. Every bash script you write should include this. See
-# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for
-# details.
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
 # Display each command as it's run.
@@ -24,10 +23,12 @@ export DEBIAN_FRONTEND=noninteractive
 # Update the package listing, so we know what packages exist:
 apt-get update
 
-# Install build-essential because sometimes Python dependencies need to build
-# C modules, particularly when upgrading to newer Python versions.  libffi-dev
-# is sometimes needed to build cffi (a cryptography dependency).
-apt-get -y install --no-install-recommends build-essential libffi-dev
+# Install various dependencies that may be required to install vo-cutouts:
+#
+# build-essential: sometimes needed to build Python modules
+# git: required by setuptools_scm
+# libffi-dev: sometimes needed to build cffi, a cryptography dependency
+apt-get -y install --no-install-recommends build-essential git libffi-dev
 
 # Delete cached files we don't need anymore:
 apt-get clean


### PR DESCRIPTION
Reduce the stages of the Docker build to three from four, since the additional stage isn't doing much for us. Move git into the install image and out of the base image, since it isn't required after package installation.