### PR TITLE
DM-48266: Remove unneeded change log

### DIFF
--- a/changelog.d/20241126_213047_steliosvoutsinas_DM_47811.md
+++ b/changelog.d/20241126_213047_steliosvoutsinas_DM_47811.md
@@ -1,9 +1,0 @@
-<!-- Delete the sections that don't apply -->
-
-### Bug fixes
-
-- Remove response_model parameters from handlers and use Annotated to address FAST001 and FAST002 ruff rules
-
-### Other changes
-
-- Update dependencies


### PR DESCRIPTION
Remove the change log for internal FastAPI linter fixes, since this didn't change user-visible behavior.