### PR TITLE
DM-49067: Switch from AsyncIterator to AsyncGenerator

### DIFF
--- a/src/datalinker/main.py
+++ b/src/datalinker/main.py
@@ -7,7 +7,9 @@ constructed when this module is loaded and is not deferred until a function is
 called.
 """
 
-from collections.abc import AsyncIterator
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from importlib.metadata import metadata, version
 
@@ -28,7 +30,7 @@ __all__ = ["app"]
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Set up and tear down the application."""
     yield
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncGenerator, Iterator
 from pathlib import Path
 
 import pytest
@@ -18,7 +18,7 @@ from .support.butler import MockButler, patch_butler
 
 
 @pytest_asyncio.fixture
-async def app(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[FastAPI]:
+async def app(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
@@ -32,7 +32,7 @@ async def app(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[FastAPI]:
 
 
 @pytest_asyncio.fixture
-async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
+async def client(app: FastAPI) -> AsyncGenerator[AsyncClient]:
     """Return an ``httpx.AsyncClient`` configured to talk to the test app.
 
     Mock the Gafaelfawr delegated token header, needed by endpoints that use


### PR DESCRIPTION
When iterators are provided by generators, use the more correct `AsyncGenerator` type instead of `AsyncIterator`.