### PR TITLE
DM-50042: Adopt PEP 639 license expressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,13 @@
 # https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 name = "datalinker"
 description = "Service and data discovery for Rubin Science Platform"
-license = {file = "LICENSE"}
+license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
-keywords = [
-    "rubin",
-    "lsst",
-]
+keywords = ["rubin", "lsst"]
 # https://pypi.org/classifiers/
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
Update the syntax of the license information in `pyproject.toml` to use PEP 639, and drop the license classifier.