### PR TITLE
DM-50042: Add do-not-upload classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Natural Language :: English",
     "Operating System :: POSIX",
+    "Private :: Do Not Upload",
     "Typing :: Typed",
 ]
 requires-python = ">=3.13"


### PR DESCRIPTION
Add the `Private :: Do Not Upload` classifier to prevent accidental uploads to PyPI.