### PR TITLE
DM-50042: Set Expires and Cache-Control on links replies

### DIFF
--- a/changelog.d/20250411_114846_rra_DM_50042.md
+++ b/changelog.d/20250411_114846_rra_DM_50042.md
@@ -1,0 +1,3 @@
+### New features
+
+- Set `Expires` and `Cache-Control` headers on the links reply reflecting the expiration time of signed image URLs, informing clients that the response should not be cached beyond the expiration of those URLs. The lifetime of the links is specified as a new configuration option for now. That option will be removed once that lifetime is available from Butler.

--- a/src/datalinker/config.py
+++ b/src/datalinker/config.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 from typing import Annotated
 
 from pydantic import Field, HttpUrl, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.logging import LogLevel, Profile
+from safir.pydantic import HumanTimedelta
 
 __all__ = [
     "Config",
@@ -41,6 +43,14 @@ class Config(BaseSettings):
             description="URL prefix used to inject the HiPS list file",
         ),
     ] = "/api/hips"
+
+    links_lifetime: Annotated[
+        HumanTimedelta,
+        Field(
+            title="Lifetime of image links replies",
+            description="Should match the lifetime of signed URLs from Butler",
+        ),
+    ] = timedelta(hours=1)
 
     log_level: Annotated[
         LogLevel,

--- a/src/datalinker/handlers/external.py
+++ b/src/datalinker/handlers/external.py
@@ -1,5 +1,7 @@
 """Handlers for the app's external root, ``/datalinker/``."""
 
+from datetime import UTC, datetime
+from email.utils import format_datetime
 from typing import Annotated, Literal
 from urllib.parse import urlencode
 
@@ -276,6 +278,8 @@ def links(
             ],
         )
 
+    lifetime = int(config.links_lifetime.total_seconds())
+    expires = datetime.now(tz=UTC) + config.links_lifetime
     return _TEMPLATES.TemplateResponse(
         request,
         "links.xml",
@@ -285,6 +289,10 @@ def links(
             "image_url": str(image_uri),
             "image_size": image_uri.size(),
             "cutout_sync_url": str(config.cutout_sync_url),
+        },
+        headers={
+            "Cache-Control": f"max-age={lifetime}",
+            "Expires": format_datetime(expires, usegmt=True),
         },
         media_type="application/x-votable+xml",
     )


### PR DESCRIPTION
Since the reply to the `{links}` endpoint contains signed URLs with an expiration time, indicate to a client that this reply should only be cached for the lifetime of those links by setting the `Expires` and `Cache-Control` headers (using the `max-age` option of the latter).