### PR TITLE
DM-50042: Prepare 3.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-3.2.0'></a>
+## 3.2.0 (2025-04-11)
+
+### New features
+
+- Set `Expires` and `Cache-Control` headers on the links reply reflecting the expiration time of signed image URLs, informing clients that the response should not be cached beyond the expiration of those URLs. The lifetime of the links is specified as a new configuration option for now. That option will be removed once that lifetime is available from Butler.
+
+### Other changes
+
+- datalinker now requires [uv](https://docs.astral.sh/uv/) for development and frozen dependencies.
+
 <a id='changelog-3.1.0'></a>
 ## 3.1.0 (2025-02-20)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #   - Runs a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.13.2-slim-bookworm AS base-image
+FROM python:3.13.3-slim-bookworm AS base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright (c) 2021-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog.d/20250410_121607_rra_DM_50042.md
+++ b/changelog.d/20250410_121607_rra_DM_50042.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- datalinker now requires [uv](https://docs.astral.sh/uv/) for development and frozen dependencies.

--- a/changelog.d/20250411_114846_rra_DM_50042.md
+++ b/changelog.d/20250411_114846_rra_DM_50042.md
@@ -1,3 +1,0 @@
-### New features
-
-- Set `Expires` and `Cache-Control` headers on the links reply reflecting the expiration time of signed image URLs, informing clients that the response should not be cached beyond the expiration of those URLs. The lifetime of the links is specified as a new configuration option for now. That option will be removed once that lifetime is available from Butler.

--- a/uv.lock
+++ b/uv.lock
@@ -547,15 +547,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/a1/7b/4b5d38f4774477a1a
 
 [[package]]
 name = "httpcore"
-version = "1.0.7"
+version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/45/ad3e1b4d448f22c0cff4f5692f5ed0666658578e358b8d58a19846048059/httpcore-1.0.8.tar.gz", hash = "sha256:86e94505ed24ea06514883fd44d2bc02d90e77e7979c8eb71b90f41d364a1bad", size = 85385 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+    { url = "https://files.pythonhosted.org/packages/18/8d/f052b1e336bb2c1fc7ed1aaed898aa570c0b61a09707b108979d9fc6e308/httpcore-1.0.8-py3-none-any.whl", hash = "sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be", size = 78732 },
 ]
 
 [[package]]


### PR DESCRIPTION
Collect change log for the 3.2.0 release. Update Python dependencies and bump the minor version of Python used to build containers. Update the copyright date in the LICENSE file.