### PR TITLE
DM-50042: Drop Expires header from {links} endpoint

### DIFF
--- a/changelog.d/20250411_142505_rra.md
+++ b/changelog.d/20250411_142505_rra.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Drop `Expires` from the reply headers of the `{links}` endpoint, since that header is effectively obsolete since HTTP/1.1 given the presence of `Cache-Control` with a `max-age` parameter.

--- a/src/datalinker/handlers/external.py
+++ b/src/datalinker/handlers/external.py
@@ -1,7 +1,5 @@
 """Handlers for the app's external root, ``/datalinker/``."""
 
-from datetime import UTC, datetime
-from email.utils import format_datetime
 from typing import Annotated, Literal
 from urllib.parse import urlencode
 
@@ -279,7 +277,6 @@ def links(
         )
 
     lifetime = int(config.links_lifetime.total_seconds())
-    expires = datetime.now(tz=UTC) + config.links_lifetime
     return _TEMPLATES.TemplateResponse(
         request,
         "links.xml",
@@ -290,9 +287,6 @@ def links(
             "image_size": image_uri.size(),
             "cutout_sync_url": str(config.cutout_sync_url),
         },
-        headers={
-            "Cache-Control": f"max-age={lifetime}",
-            "Expires": format_datetime(expires, usegmt=True),
-        },
+        headers={"Cache-Control": f"max-age={lifetime}"},
         media_type="application/x-votable+xml",
     )

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-from email.utils import parsedate_to_datetime
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
@@ -12,7 +10,6 @@ import pytest
 from httpx import AsyncClient
 from jinja2 import Environment, PackageLoader, select_autoescape
 from lsst.daf.butler import LabeledButlerFactory
-from safir.datetime import current_datetime
 
 from datalinker.config import config
 
@@ -197,7 +194,6 @@ async def test_links(client: AsyncClient, mock_butler: MockButler) -> None:
         f"https://presigned-url.example.com/{mock_butler.uuid!s}"
         "?X-Amz-Signature=abcdef"
     )
-    expected_expires = current_datetime() + config.links_lifetime
 
     # Use iD to test the IVOA requirement of case insensitive parameters.
     r = await client.get(
@@ -205,9 +201,6 @@ async def test_links(client: AsyncClient, mock_butler: MockButler) -> None:
         params={"iD": f"butler://label-http/{mock_butler.uuid!s}"},
     )
     assert r.status_code == 200
-    expires = parsedate_to_datetime(r.headers["Expires"])
-    assert expected_expires <= expires
-    assert expires <= expected_expires + timedelta(seconds=5)
     lifetime = int(config.links_lifetime.total_seconds())
     assert r.headers["Cache-Control"] == f"max-age={lifetime}"
 


### PR DESCRIPTION
MDN says that `Expires` is effectively obsolete since HTTP/1.1 given the presence of a `Cache-Control` header with `max-age`, so drop it.