### PR TITLE
DM-52588: Add initial implementation of timeseries join on `visit` and `detector`

### DIFF
--- a/changelog.d/20250924_133732_jeremym_DM_52588.md
+++ b/changelog.d/20250924_133732_jeremym_DM_52588.md
@@ -1,0 +1,6 @@
+### New features
+
+- Added support for joining on ``visit`` and ``detector`` columns when
+  constructing time series using ``join_style`` parameter, which can be
+  either ``ccdVisit`` (the original scheme) or ``visit_detector`` for
+  the new one.

--- a/tests/data/columns-principal.yaml
+++ b/tests/data/columns-principal.yaml
@@ -306,6 +306,29 @@ tables:
     tap:principal: []
   dp02_test_PREOPS863_00.Visit:
     tap:principal: []
+  dp1.CcdVisit:
+    tap:principal:
+    - band
+    - dec
+    - detector
+    - expTime
+    - magLim
+    - psfSigma
+    - ra
+    - seeing
+    - zenithDistance
+    - visitId
+    - expMidptMJD
+  dp1.ForcedSource:
+    tap:principal:
+    - band
+    - detector
+    - objectId
+    - psfDiffFlux
+    - psfDiffFluxErr
+    - psfFlux
+    - psfFluxErr
+    - visit
   ivoa.ObsCore:
     tap:principal:
     - dataproduct_type


### PR DESCRIPTION
This updates the Datalinker so that it supports using the `visit` and `detector` compound key in joins for constructing the time series data. A `join_style` parameter was added which uses the old (DP0.2) style join as the default.