### PR TITLE
DM-52601: Add optional Sentry support

### DIFF
--- a/changelog.d/20250923_171313_rra_DM_52601.md
+++ b/changelog.d/20250923_171313_rra_DM_52601.md
@@ -1,0 +1,3 @@
+### New features
+
+- Add optional support for reporting exceptions to Sentry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "pydantic-settings>=2",
     "pyyaml>=6",
     "rubin-repertoire>=0.3.0",
-    "safir>=6.2.0",
+    "safir>=13",
     "structlog>=25",
     "uvicorn[standard]>=0.34",
 ]

--- a/src/datalinker/main.py
+++ b/src/datalinker/main.py
@@ -16,13 +16,17 @@ from fastapi import FastAPI
 from safir.logging import Profile, configure_logging, configure_uvicorn_logging
 from safir.middleware.ivoa import CaseInsensitiveQueryMiddleware
 from safir.middleware.x_forwarded import XForwardedMiddleware
+from safir.sentry import initialize_sentry
 from safir.slack.webhook import SlackRouteErrorHandler
 
+from . import __version__
 from .config import config
 from .handlers.external import external_router
 from .handlers.internal import internal_router
 
 __all__ = ["app"]
+
+initialize_sentry(release=__version__)
 
 app = FastAPI(
     title="datalinker",

--- a/uv.lock
+++ b/uv.lock
@@ -368,7 +368,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2" },
     { name = "pyyaml", specifier = ">=6" },
     { name = "rubin-repertoire", specifier = ">=0.3.0" },
-    { name = "safir", specifier = ">=6.2.0" },
+    { name = "safir", specifier = ">=13" },
     { name = "structlog", specifier = ">=25" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]


### PR DESCRIPTION
Call the Safir Sentry initialization function at module load time to support optional reporting of exceptions to Sentry.