### PR TITLE
DM-52601: Remove TEST_DATA_DIR test constant

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ from rubin.repertoire import Discovery, register_mock_discovery
 from datalinker import main
 from datalinker.config import config
 
-from .constants import TEST_DATA_DIR
 from .support.butler import MockButler, patch_butler
 
 
@@ -27,7 +26,8 @@ async def app(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[FastAPI]:
     Wraps the application in a lifespan manager so that startup and shutdown
     events are sent during test execution.
     """
-    monkeypatch.setattr(config, "tap_metadata_dir", TEST_DATA_DIR)
+    test_data_path = Path(__file__).parent / "data"
+    monkeypatch.setattr(config, "tap_metadata_dir", test_data_path)
     async with LifespanManager(main.app):
         yield main.app
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,9 +1,0 @@
-"""Constants for crawlspace tests."""
-
-from pathlib import Path
-
-__all__ = ["TEST_DATA_DIR"]
-
-
-TEST_DATA_DIR = Path(__file__).parent / "data"
-"""Directory that contains test data."""


### PR DESCRIPTION
Inline the one use into the `app` fixture and remove the constant and `tests/constants.py`.