### PR TITLE
DM-52622: Remove unneeded constants

### DIFF
--- a/src/datalinker/constants.py
+++ b/src/datalinker/constants.py
@@ -1,14 +1,10 @@
 """Constants for datalinker."""
 
-from pathlib import Path
-
-__all__ = ["CONFIG_PATH", "CONFIG_PATH_ENV_VAR"]
-
-CONFIG_PATH = Path("/etc/datalinker/config.yaml")
-"""Default path to configuration."""
-
-CONFIG_PATH_ENV_VAR = "DATALINKER_CONFIG_PATH"
-"""Env var to load config path from."""
+__all__ = [
+    "ADQL_COMPOUND_TABLE_REGEX",
+    "ADQL_FOREIGN_COLUMN_REGEX",
+    "ADQL_IDENTIFIER_REGEX",
+]
 
 ADQL_COMPOUND_TABLE_REGEX = r"^([a-zA-Z0-9_]+\.)?[a-zA-Z0-9_.]+$"
 """ADQL table with optional prefix."""


### PR DESCRIPTION
Drop some stray constants that were no longer used since the configuration was changed back to environment variables.