### PR TITLE
DM-55406: Update mypy configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,16 @@ exclude_lines = [
 [tool.mypy]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+enable_error_code = [
+    "deprecated",
+    "exhaustive-match",
+    "explicit-override",
+    "ignore-without-code",
+    "redundant-expr",
+    "redundant-self",
+    "truthy-iterable",
+    "unused-awaitable",
+]
 ignore_missing_imports = true
 local_partial_types = true
 plugins = ["pydantic.mypy"]

--- a/tests/support/butler.py
+++ b/tests/support/butler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, override
 from unittest.mock import Mock, patch
 from uuid import UUID, uuid4
 
@@ -36,6 +36,7 @@ class MockButler(Mock):
             return f"s3://some-bucket/{ref.uuid!s}"
         return self.mock_uri
 
+    @override
     def _get_child_mock(self, /, **kwargs: Any) -> Mock:
         return Mock(**kwargs)
 


### PR DESCRIPTION
Use the current standard mypy configuration and add one missing `@override` decorator.