### PR TITLE
DM-55406: Remove older type annotation approach

### DIFF
--- a/src/datalinker/config.py
+++ b/src/datalinker/config.py
@@ -1,7 +1,5 @@
 """Configuration definition."""
 
-from __future__ import annotations
-
 from datetime import timedelta
 from pathlib import Path
 from typing import Annotated

--- a/src/datalinker/exceptions.py
+++ b/src/datalinker/exceptions.py
@@ -1,7 +1,5 @@
 """Exceptions for datalinker."""
 
-from __future__ import annotations
-
 from fastapi import status
 from safir.fastapi import ClientRequestError
 

--- a/src/datalinker/factory.py
+++ b/src/datalinker/factory.py
@@ -1,7 +1,5 @@
 """Component factory for datalinker."""
 
-from __future__ import annotations
-
 from lsst.daf.butler import LabeledButlerFactoryProtocol
 from rubin.repertoire import DiscoveryClient
 from structlog.stdlib import BoundLogger

--- a/src/datalinker/main.py
+++ b/src/datalinker/main.py
@@ -7,8 +7,6 @@ constructed when this module is loaded and is not deferred until a function is
 called.
 """
 
-from __future__ import annotations
-
 from importlib.metadata import metadata, version
 
 import structlog

--- a/src/datalinker/models.py
+++ b/src/datalinker/models.py
@@ -1,7 +1,5 @@
 """Models for datalinker."""
 
-from __future__ import annotations
-
 from dataclasses import asdict, dataclass
 from enum import StrEnum
 

--- a/src/datalinker/services/links.py
+++ b/src/datalinker/services/links.py
@@ -1,7 +1,5 @@
 """Generate a DataLink response for an identifier."""
 
-from __future__ import annotations
-
 from lsst.daf.butler import Butler, LabeledButlerFactoryProtocol
 from rubin.repertoire import DiscoveryClient
 from structlog.stdlib import BoundLogger

--- a/src/datalinker/templates.py
+++ b/src/datalinker/templates.py
@@ -4,8 +4,6 @@ Provides a shared Jinja template environment used for generating templated
 responses.
 """
 
-from __future__ import annotations
-
 from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, PackageLoader, StrictUndefined
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 """Test fixtures for datalinker tests."""
 
-from __future__ import annotations
-
 from collections.abc import AsyncGenerator, Iterator
 from pathlib import Path
 

--- a/tests/handlers/external_test.py
+++ b/tests/handlers/external_test.py
@@ -1,7 +1,5 @@
 """Tests for the datalinker.handlers.external module and routes."""
 
-from __future__ import annotations
-
 from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4

--- a/tests/handlers/internal_test.py
+++ b/tests/handlers/internal_test.py
@@ -1,7 +1,5 @@
 """Tests for the datalinker.handlers.internal module and routes."""
 
-from __future__ import annotations
-
 import pytest
 from httpx import AsyncClient
 

--- a/tests/support/butler.py
+++ b/tests/support/butler.py
@@ -1,7 +1,5 @@
 """Mock Butler for testing."""
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 from typing import Any, override
 from unittest.mock import Mock, patch


### PR DESCRIPTION
Remove `from __future__ import annotations` from all files. This is deprecated in Python and is slowly being phased out.