### PR TITLE
DM-55406: Prevent uv from managing Docker Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # cache on a separate file system.
 ENV UV_LINK_MODE=copy
 
+# Force use of system Python so that the Python version is controlled by
+# the Docker base image version, not by whatever uv decides to install.
+ENV UV_PYTHON_PREFERENCE=only-system
+
 # Install the dependencies.
 WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \


### PR DESCRIPTION
Ensure that the Docker build uses the Python provided by the base container and the package installation fails if that version is incompatible rather than letting uv silently install a different version of Python.