### PR TITLE
DM-55406: Update shared Ruff configuration file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,6 @@ extend = "ruff-shared.toml"
 
 [tool.ruff.lint.isort]
 known-first-party = ["datalinker", "tests"]
-split-on-trailing-comma = false
 
 [tool.scriv]
 categories = [

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -33,6 +33,7 @@ ignore = [
     "ARG003",   # unused class method arguments are often legitimate
     "ARG005",   # unused lambda arguments are often legitimate
     "ASYNC109", # many async functions use asyncio.timeout internally
+    "ASYNC240", # we don't want to run filesystem operations on threads
     "BLE001",   # we want to catch and report Exception in background tasks
     "C414",     # nested sorted is how you sort by multiple keys with reverse
     "D102",     # sometimes we use docstring inheritence
@@ -145,6 +146,9 @@ builtins-ignorelist = [
 [lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false
+
+[lint.isort]
+split-on-trailing-comma = false
 
 [lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
Remove a setting from `pyproject.toml` that's now provided by the shared configuration.