### PR TITLE
DM-55406: Use service discovery to get Butler configuration

### DIFF
--- a/changelog.d/20260707_142318_rra_DM_55406.md
+++ b/changelog.d/20260707_142318_rra_DM_55406.md
@@ -1,0 +1,3 @@
+### New features
+
+- Use the Repertoire discovery client to get Butler configuration. This removes the need to inject `DAF_BUTLER_REPOSITORY_INDEX` into the application's environment.

--- a/src/datalinker/dependencies/context.py
+++ b/src/datalinker/dependencies/context.py
@@ -41,19 +41,20 @@ class ContextDependency:
     """
 
     def __init__(self) -> None:
-        self._butler_factory = LabeledButlerFactory()
+        self._butler_factory: LabeledButlerFactory | None = None
 
     async def __call__(
         self,
         *,
         request: Request,
         discovery: Annotated[DiscoveryClient, Depends(discovery_dependency)],
-        delegated_token: Annotated[
-            str, Depends(auth_delegated_token_dependency)
-        ],
+        token: Annotated[str, Depends(auth_delegated_token_dependency)],
         logger: Annotated[BoundLogger, Depends(logger_dependency)],
     ) -> RequestContext:
-        bound_factory = self._butler_factory.bind(access_token=delegated_token)
+        if not self._butler_factory:
+            butler_repositories = await discovery.butler_repositories()
+            self._butler_factory = LabeledButlerFactory(butler_repositories)
+        bound_factory = self._butler_factory.bind(access_token=token)
         factory = Factory(bound_factory, discovery, logger)
         return RequestContext(request=request, factory=factory, logger=logger)
 

--- a/tests/data/discovery.json
+++ b/tests/data/discovery.json
@@ -1,6 +1,7 @@
 {
   "datasets": {
     "label-http": {
+      "butler_config": "https://example.com/api/butler/repo/label/butler.yaml",
       "services": {
         "cutout": {
           "url": "https://data.example.com/api/cutout",
@@ -18,6 +19,7 @@
       }
     },
     "label-raw": {
+      "butler_config": "https://example.com/api/butler/repo/label/butler.yaml",
       "services": {
         "cutout": {
           "url": "https://data.example.com/api/cutout",


### PR DESCRIPTION
Use the Repertoire discovery client to get Butler configuration. This removes the need to inject `DAF_BUTLER_REPOSITORY_INDEX` into the application's environment.