### PR TITLE
DM-55406: Add the DataLink 1.1 INFO tag to the links reply

### DIFF
--- a/changelog.d/20260709_105611_rra_DM_55406.md
+++ b/changelog.d/20260709_105611_rra_DM_55406.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Add the required `<INFO>` tag to the links reply to indicate compliance with the IVOA DataLink 1.1 standard.

--- a/src/datalinker/templates/links.xml
+++ b/src/datalinker/templates/links.xml
@@ -4,6 +4,7 @@
          xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/VOTable-1.4.xsd">
  <RESOURCE type="results">
   <TABLE>
+   <INFO name="standardID" value="ivo://ivoa.net/std/DataLink#links-1.1"/>
    <DESCRIPTION>Links table for observation dataset {{ id }}</DESCRIPTION>
    <FIELD ID="ID" arraysize="*" datatype="char"
           name="ID" ucd="meta.id;meta.main"/>

--- a/tests/data/links/calexp-nocutout.xml
+++ b/tests/data/links/calexp-nocutout.xml
@@ -4,6 +4,7 @@
          xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/VOTable-1.4.xsd">
  <RESOURCE type="results">
   <TABLE>
+   <INFO name="standardID" value="ivo://ivoa.net/std/DataLink#links-1.1"/>
    <DESCRIPTION>Links table for observation dataset butler://dr2/ac691f52-c1a0-4199-b049-182cf403dc37</DESCRIPTION>
    <FIELD ID="ID" arraysize="*" datatype="char"
           name="ID" ucd="meta.id;meta.main"/>

--- a/tests/data/links/calexp.xml
+++ b/tests/data/links/calexp.xml
@@ -4,6 +4,7 @@
          xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/VOTable-1.4.xsd">
  <RESOURCE type="results">
   <TABLE>
+   <INFO name="standardID" value="ivo://ivoa.net/std/DataLink#links-1.1"/>
    <DESCRIPTION>Links table for observation dataset butler://dr1/ac691f52-c1a0-4199-b049-182cf403dc37</DESCRIPTION>
    <FIELD ID="ID" arraysize="*" datatype="char"
           name="ID" ucd="meta.id;meta.main"/>

--- a/tests/data/links/raw.xml
+++ b/tests/data/links/raw.xml
@@ -4,6 +4,7 @@
          xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/VOTable-1.4.xsd">
  <RESOURCE type="results">
   <TABLE>
+   <INFO name="standardID" value="ivo://ivoa.net/std/DataLink#links-1.1"/>
    <DESCRIPTION>Links table for observation dataset butler://dr1/c6956c99-88d9-4678-a3df-36dd913dd4bc</DESCRIPTION>
    <FIELD ID="ID" arraysize="*" datatype="char"
           name="ID" ucd="meta.id;meta.main"/>


### PR DESCRIPTION
Add the required `<INFO>` tag to the links reply to indicate compliance with the IVOA DataLink 1.1 standard.